### PR TITLE
feat: add update autofocus z position + tests

### DIFF
--- a/docs/schema/event.md
+++ b/docs/schema/event.md
@@ -4,19 +4,21 @@
     options:
         members: []
 
+::: useq._mda_event.Channel
+    options:
+        members: []
+
 ::: useq.PropertyTuple
     options:
         members: []
 
-::: useq._mda_event.Channel
-    options:
-        members: []
+## Event Actions
 
 ::: useq.Action
     options:
         members: []
 
-::: useq.Snap
+::: useq.AcquireImage
     options:
         members: []
 

--- a/docs/schema/hardware_autofocus.md
+++ b/docs/schema/hardware_autofocus.md
@@ -1,6 +1,6 @@
-## Hardware Autofocus
+# Hardware Autofocus Plan
 
-Ways to describe hardware-based autofocus.
+Ways to describe a hardware-based autofocus plan.
 
 ::: useq.AutoFocusPlan
     options:
@@ -13,6 +13,7 @@ Ways to describe hardware-based autofocus.
 
 ::: useq.AxesBasedAF
     options:
+        show_source: true
         show_signature: true
         show_signature_annotations: true
         members:

--- a/docs/schema/hardware_autofocus.md
+++ b/docs/schema/hardware_autofocus.md
@@ -1,0 +1,23 @@
+## Hardware Autofocus
+
+Ways to describe hardware-based autofocus.
+
+::: useq.AutoFocusPlan
+    options:
+        show_signature: true
+        show_signature_annotations: true
+        members:
+            - as_action
+            - event
+            - should_autofocus
+
+::: useq.AxesBasedAF
+    options:
+        show_signature: true
+        show_signature_annotations: true
+        members:
+            - should_autofocus
+
+::: useq.NoAF
+    options:
+        members: []

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
         - schema/sequence.md
         - schema/event.md
         - schema/axes.md
+        - schema/hardware_autofocus.md
       - api.md
   - pymmcore-widgets: /pymmcore-widgets/
 

--- a/src/useq/__init__.py
+++ b/src/useq/__init__.py
@@ -1,7 +1,7 @@
 from ._actions import AcquireImage, Action, HardwareAutofocus
 from ._channel import Channel
 from ._grid import AnyGridPlan, GridFromEdges, GridRelative, NoGrid
-from ._hardware_autofocus import AnyAutofocusPlan, AxesBasedAF, NoAF
+from ._hardware_autofocus import AnyAutofocusPlan, AutoFocusPlan, AxesBasedAF, NoAF
 from ._mda_event import MDAEvent, PropertyTuple
 from ._mda_sequence import MDASequence
 from ._position import Position
@@ -26,6 +26,7 @@ __all__ = [
     "Action",
     "AnyAutofocusPlan",
     "AnyGridPlan",
+    "AutoFocusPlan",
     "AxesBasedAF",
     "Channel",
     "GridFromEdges",

--- a/src/useq/_actions.py
+++ b/src/useq/_actions.py
@@ -4,7 +4,7 @@ from ._base_model import FrozenModel
 
 
 class Action(FrozenModel):
-    """Base class for all [`useq.MDAEvent`][] actions.
+    """Base class for all [`MDAEvent`][useq.MDAEvent] `Actions`.
 
     Parameters
     ----------
@@ -16,7 +16,7 @@ class Action(FrozenModel):
 
 
 class AcquireImage(Action):
-    """Action to acquire an image.
+    """`Action` to acquire an image.
 
     Attributes
     ----------
@@ -28,7 +28,7 @@ class AcquireImage(Action):
 
 
 class HardwareAutofocus(Action):
-    """Action to perform a hardware autofocus.
+    """`Action` to perform a hardware autofocus.
 
     Attributes
     ----------

--- a/src/useq/_actions.py
+++ b/src/useq/_actions.py
@@ -46,8 +46,11 @@ class HardwareAutofocus(Action):
     autofocus_motor_offset: float
         Before autofocus is performed, the autofocus motor should be moved to this
         offset.
+    max_retries : int
+        The number of retries if autofocus fails. By default, 3.
     """
 
     type: Literal["hardware_autofocus"] = "hardware_autofocus"
     autofocus_device_name: str
     autofocus_motor_offset: float
+    max_retries: int = 3

--- a/src/useq/_actions.py
+++ b/src/useq/_actions.py
@@ -4,7 +4,12 @@ from ._base_model import FrozenModel
 
 
 class Action(FrozenModel):
-    """Base class for all [`MDAEvent`][useq.MDAEvent] `Actions`.
+    """Base class for a [`MDAEvent`][useq.MDAEvent] `action`.
+
+    An `Action` specifies what task should be performed during a
+    [`MDAEvent`][useq.MDAEvent]. An `Action` can be for example used to acquire an
+    image ([`AcquireImage`][useq.AcquireImage]) or to perform a hardware autofocus
+    ([`HardwareAutofocus`][useq.HardwareAutofocus]).
 
     Parameters
     ----------
@@ -16,7 +21,7 @@ class Action(FrozenModel):
 
 
 class AcquireImage(Action):
-    """`Action` to acquire an image.
+    """[`Action`][useq.Action] to acquire an image.
 
     Attributes
     ----------
@@ -28,7 +33,9 @@ class AcquireImage(Action):
 
 
 class HardwareAutofocus(Action):
-    """`Action` to perform a hardware autofocus.
+    """[`Action`][useq.Action] to perform a hardware autofocus.
+
+    See also [`AutoFocusPlan`][useq.AutoFocusPlan].
 
     Attributes
     ----------

--- a/src/useq/_hardware_autofocus.py
+++ b/src/useq/_hardware_autofocus.py
@@ -24,17 +24,23 @@ class AutoFocusPlan(FrozenModel):
     autofocus_motor_offset: Optional[float] = None
 
     def as_action(self) -> HardwareAutofocus:
-        """Return a [`HardwareAutofocus`][useq.HardwareAutofocus][`Action`][useq.Action] for this autofocus plan."""  # noqa: E501
+        """Return a [`HardwareAutofocus`][useq.HardwareAutofocus] [`Action`][useq.Action]
+        for this autofocus plan.
+        """  # noqa: D205, E501
         return HardwareAutofocus(
             autofocus_device_name=self.autofocus_device_name,
             autofocus_motor_offset=self.autofocus_motor_offset,
         )
 
     def event(self, event: MDAEvent, zplan: AnyZPlan) -> Optional[MDAEvent]:
-        """Return a new autofocus event if autofocus should be performed.
+        """Return a new [`MDAEvent`][useq.MDAEvent] with a
+        [`HardwareAutofocus`][useq.HardwareAutofocus] [`Action`][useq.Action]
+        if [should_autofocus][useq.AutoFocusPlan.should_autofocus] returns `True`.
 
-        Also update the z position of the autofocus event if a zplan is provided.
-        """
+        The z position of the new [`useq.MDAEvent`][] is also updated if a relative
+        zplan is provided since autofocus shuld be performed on the home z stack
+        position.
+        """  # noqa: D205
         if self.should_autofocus(event):
             new_z: Optional[float] = None
             if event.z_pos is None:
@@ -50,7 +56,8 @@ class AutoFocusPlan(FrozenModel):
     def should_autofocus(self, event: MDAEvent) -> bool:
         """Method that must be implemented by a subclass.
 
-        Should return True if autofocus should be performed at this event.
+        Should return True if autofocus should be performed (see
+        [`AxesBasedAF`][useq.AxesBasedAF]).
         """
         raise NotImplementedError("should_autofocus() must be implemented by subclass.")
 
@@ -71,10 +78,10 @@ class AxesBasedAF(AutoFocusPlan):
     _previous: dict = PrivateAttr(default_factory=dict)
 
     def should_autofocus(self, event: MDAEvent) -> bool:
-        """Return True if autofocus should be performed at this event.
+        """Return `True` if autofocus should be performed at this event.
 
-        ...if any of the axes specified in `axes` have changed from the previous
-        event.
+        Will return `True` if any of the axes specified in `axes` have changed from the
+        previous event.
         """
         self._previous, previous = dict(event.index), self._previous
         for axis, index in event.index.items():

--- a/src/useq/_hardware_autofocus.py
+++ b/src/useq/_hardware_autofocus.py
@@ -38,7 +38,7 @@ class AutoFocusPlan(FrozenModel):
             new_z: Optional[float] = None
             if event.z_pos is None:
                 new_z = None
-            elif "z" not in event.index or zplan is None or isinstance(zplan, NoZ):
+            elif "z" not in event.index or isinstance(zplan, NoZ):
                 new_z = event.z_pos
             else:
                 new_z = event.z_pos - list(zplan)[event.index["z"]]

--- a/src/useq/_hardware_autofocus.py
+++ b/src/useq/_hardware_autofocus.py
@@ -24,6 +24,7 @@ class AutoFocusPlan(FrozenModel):
     autofocus_motor_offset: Optional[float] = None
 
     def as_action(self) -> HardwareAutofocus:
+        """Return a [`HardwareAutofocus`][useq.HardwareAutofocus][`Action`][useq.Action] for this autofocus plan."""  # noqa: E501
         return HardwareAutofocus(
             autofocus_device_name=self.autofocus_device_name,
             autofocus_motor_offset=self.autofocus_motor_offset,
@@ -47,6 +48,10 @@ class AutoFocusPlan(FrozenModel):
         return None
 
     def should_autofocus(self, event: MDAEvent) -> bool:
+        """Method that must be implemented by a subclass.
+
+        Should return True if autofocus should be performed at this event.
+        """
         raise NotImplementedError("should_autofocus() must be implemented by subclass.")
 
 
@@ -66,8 +71,11 @@ class AxesBasedAF(AutoFocusPlan):
     _previous: dict = PrivateAttr(default_factory=dict)
 
     def should_autofocus(self, event: MDAEvent) -> bool:
-        # If any of the axes specified in self.axes have changed from the previous
-        # event, then return True.
+        """Return True if autofocus should be performed at this event.
+
+        ...if any of the axes specified in `axes` have changed from the previous
+        event.
+        """
         self._previous, previous = dict(event.index), self._previous
         for axis, index in event.index.items():
             if axis in self.axes and previous.get(axis) != index:

--- a/src/useq/_mda_sequence.py
+++ b/src/useq/_mda_sequence.py
@@ -496,7 +496,7 @@ def iter_sequence(
 
         event = MDAEvent(**event_kwargs)
         if autofocus_plan:
-            af_event = autofocus_plan.event(event)
+            af_event = autofocus_plan.event(event, sequence.z_plan)
             if af_event is not None:
                 yield af_event
         yield event

--- a/tests/test_autofocus.py
+++ b/tests/test_autofocus.py
@@ -49,20 +49,6 @@ def test_autofocus(
     assert tuple(expected_af_indices) == tuple(actual)
 
 
-# def _af_seq(axis: tuple[str, ...] | None, gplan: bool = False, zplan: bool = False, tplan: bool = False):
-#     import numpy as np
-#     # sourcery skip: use-dictionary-union
-#     """Helper function to create a sub-sequence with autofocus."""
-#     af = {
-#             "autofocus_plan": AxesBasedAF(autofocus_device_name="Z", autofocus_motor_offset=np.random.randint(1, 100), axes=axis)
-#             if axis else NoAF()
-#         }
-#     gp = {"grid_plan": {"rows": 2, "columns": 1}} if gplan else {}
-#     zp = {"z_plan": {"range": 2, "step": 1}} if zplan else {}
-#     tplan = {"time_plan": [{"interval": 1, "loops": 2}]} if tplan else {}
-
-#     return {**af, **gp, **zp, **tplan}
-
 AF = AxesBasedAF(autofocus_device_name="Z", autofocus_motor_offset=40, axes=())
 AF_C = AF.copy(update={"axes": ("c",)})
 AF_G = AF.copy(update={"axes": ("g",)})
@@ -91,28 +77,6 @@ AF_SUB_TESTS: list[tuple[MDASequence, tuple[str, ...], Iterable[int]]] = [
     (TWO_CH.replace(stage_positions=[ZPOS_30, useq.Position(z=10, sequence=MDASequence(autofocus_plan=AF_C, grid_plan=GRID_PLAN))]), (), (2, 5)),
     (TWO_CH.replace(stage_positions=[SUB_P_AF_C, useq.Position(z=10, sequence=MDASequence(autofocus_plan=AF_G, grid_plan=GRID_PLAN))]), (), range(0, 11, 2)),
 ]
-# fmt: on
-# # order, af axis, channels, pos_plan, z_plan, grid_plan, time_plan, expected_af_event_indexes
-# mdas = [
-
-#     ("tpgcz", (), ["DAPI", "FITC"], [{"z": 30, "sequence": _af_seq(("c",))}, {"z": 10, "sequence": _af_seq(("g",), True)}], {}, {}, {}, tuple(range(0, 11, 2))),
-#     ("tpgcz", (), ["DAPI", "FITC"], [{"z": 30, "sequence": _af_seq(("c",), False, True)}, {"z": 10, "sequence": _af_seq(("g",), True)}], {}, {}, {}, (0, 4, *tuple(range(8, 15, 2)))),
-#     ("tpgcz", ("z",), ["DAPI", "FITC"], [{"z": 30}, {"z": 10, "sequence": _af_seq(None, False, True)}], {}, {}, {}, tuple(range(2, 13, 2))),
-#     ("tpgcz", (), ["DAPI", "FITC"], [{"z": 30}, {"z": 30, "sequence": _af_seq(("p", "g"), True)},], {}, {}, {}, (2, 4, 6, 8)),
-#     ("tpgcz", (), ["DAPI", "FITC"], [{"z": 30, "sequence": _af_seq(("p",), True)}, {"z": 10, "sequence": _af_seq(("p", "g"), True)},], {}, {}, {}, (0, 5, 7, 9, 11)),
-#     ("tpgcz", (), ["DAPI", "FITC"], [{"z": 30, "sequence": _af_seq(("p","g"), True)}, {"z": 10, "sequence": _af_seq(("p", "g"), True)},], {}, {}, {}, tuple(range(0, 15, 2))),
-#     ("tpgcz", (), ["DAPI", "FITC"], [{"z": 30, "sequence": _af_seq(("p","c"), True)}, {"z": 10, "sequence": _af_seq(("p", "g"), True)},], {}, {}, {}, (0, 3, 6, 8, 10, 12)),
-#     ("tpgcz", (), ["DAPI", "FITC"], [
-#         {"z": 30, "sequence": _af_seq(("t","p","g"), True)},
-#         {"z": 10, "sequence": _af_seq(("t","p","g"), True)},
-#         {"z": 10, "sequence": _af_seq(("t","p","g"), True)},
-#         ], {}, {}, {"interval": 1, "loops": 2}, tuple(range(0, 47, 2))),
-#     ("tpgcz", (), ["DAPI", "FITC"], [
-#         {"z": 30, "sequence": _af_seq(("t","p"), True)},
-#         {"z": 10, "sequence": _af_seq(("t","p"), True)},
-#         {"z": 10, "sequence": _af_seq(("t","p"), True)},
-#         ], {}, {}, {"interval": 1, "loops": 2}, tuple(range(0, 26, 5))),
-# ]
 
 
 @pytest.mark.parametrize("mda, global_af_axes, expected_af_indices", AF_SUB_TESTS)

--- a/tests/test_autofocus.py
+++ b/tests/test_autofocus.py
@@ -108,6 +108,14 @@ def test_autofocus_z_pos() -> None:
     z = [e.z_pos for e in mda]
     assert z[0] == z[4] == 200
 
+def test_autofocus_z_pos_abovebelow() -> None:
+    mda = TWO_CH.replace(stage_positions=[ZPOS_200], z_plan=useq.ZAboveBelow(above=2, below=2, step=1))
+    af_plan = AxesBasedAF(
+        autofocus_device_name="Z", autofocus_motor_offset=50, axes=("c",)
+    )
+    mda = mda.replace(autofocus_plan=af_plan)
+    z = [e.z_pos for e in mda]
+    assert z[0] == z[6] == 200
 
 def test_autofocus_z_pos_af_sub_sequence() -> None:
     mda = TWO_CH.replace(stage_positions=[SUB_P_AF_C], z_plan=ZRANGE2)

--- a/tests/test_autofocus.py
+++ b/tests/test_autofocus.py
@@ -133,3 +133,38 @@ def test_autofocus_sub_sequence(
     expected = list(expected_af_indices)
     if expected != actual:
         raise AssertionError(f"Expected AF indices at {expected} but got {actual}")
+
+
+def test_autofocus_z_pos() -> None:
+    mda = TWO_CH.replace(stage_positions=[ZPOS_200], z_plan=ZRANGE2)
+    af_plan = AxesBasedAF(
+        autofocus_device_name="Z", autofocus_motor_offset=50, axes=("c",)
+    )
+    mda = mda.replace(autofocus_plan=af_plan)
+    z = [e.z_pos for e in mda]
+    assert z[0] == z[4] == 200
+
+
+def test_autofocus_z_pos_af_sub_sequence() -> None:
+    mda = TWO_CH.replace(stage_positions=[SUB_P_AF_C], z_plan=ZRANGE2)
+    z = [e.z_pos for e in mda]
+    assert z[0] == z[4] == 10
+
+
+def test_autofocus_z_pos_af_sub_sequence_zplan() -> None:
+    mda = TWO_CH_SUBPAF_C
+    z = [e.z_pos for e in mda]
+    assert z[2] == z[4] == 10
+
+
+def test_autofocus_z_pos_multi_plans() -> None:
+    mda = TWO_CH.replace(
+        stage_positions=[ZPOS_200], grid_plan=GRID_PLAN, z_plan=ZRANGE2
+    )
+    af_plan = AxesBasedAF(
+        autofocus_device_name="Z", autofocus_motor_offset=50, axes=("c",)
+    )
+    mda = mda.replace(autofocus_plan=af_plan)
+    z = [e.z_pos for e in mda]
+    indexes = [0, 4, 8, 12]
+    assert [z[i] for i in indexes] == [200] * len(indexes)


### PR DESCRIPTION
This PR adds a logic to the `AutoFocusPlan` `event` method to get and update the z position that should be used in the autofocus event in case of a relative zplan.